### PR TITLE
Add salt, tomato and onion to c tags and make recipes use them

### DIFF
--- a/src/main/resources/data/bonappetit/recipes/butter.json
+++ b/src/main/resources/data/bonappetit/recipes/butter.json
@@ -5,10 +5,10 @@
             "item": "bonappetit:cream"
         },
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         }
     ],
     "result": {

--- a/src/main/resources/data/bonappetit/recipes/carrot_salad.json
+++ b/src/main/resources/data/bonappetit/recipes/carrot_salad.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
             "item": "bonappetit:leek"

--- a/src/main/resources/data/bonappetit/recipes/cheese.json
+++ b/src/main/resources/data/bonappetit/recipes/cheese.json
@@ -8,7 +8,7 @@
             "item": "minecraft:milk_bucket"
         },
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         }
     ],
     "result": {

--- a/src/main/resources/data/bonappetit/recipes/cheese_croquettes.json
+++ b/src/main/resources/data/bonappetit/recipes/cheese_croquettes.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
             "item": "bonappetit:cheese"

--- a/src/main/resources/data/bonappetit/recipes/cheese_soup.json
+++ b/src/main/resources/data/bonappetit/recipes/cheese_soup.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
             "item": "bonappetit:cheese"

--- a/src/main/resources/data/bonappetit/recipes/dough.json
+++ b/src/main/resources/data/bonappetit/recipes/dough.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
             "item": "minecraft:sugar"

--- a/src/main/resources/data/bonappetit/recipes/fried_egg.json
+++ b/src/main/resources/data/bonappetit/recipes/fried_egg.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
             "item": "minecraft:egg"

--- a/src/main/resources/data/bonappetit/recipes/onion_soup.json
+++ b/src/main/resources/data/bonappetit/recipes/onion_soup.json
@@ -2,13 +2,13 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "bonappetit:salt"
+            "tag": "c:salt"
         },
         {
-            "item": "bonappetit:onion"
+            "tag": "c:onion"
         },
         {
-            "item": "bonappetit:onion"
+            "tag": "c:onion"
         },
         {
             "item": "bonappetit:cooking_pot"

--- a/src/main/resources/data/c/tags/items/onion.json
+++ b/src/main/resources/data/c/tags/items/onion.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bonappetit:onion"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/salt.json
+++ b/src/main/resources/data/c/tags/items/salt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bonappetit:salt"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tomato.json
+++ b/src/main/resources/data/c/tags/items/tomato.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bonappetit:tomato"
+  ]
+}

--- a/src/main/resources/data/minecraft/recipes/beetroot_soup.json
+++ b/src/main/resources/data/minecraft/recipes/beetroot_soup.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "bonappetit:salt"
+      "tag": "c:salt"
     },
     {
       "item": "minecraft:beetroot"

--- a/src/main/resources/data/minecraft/recipes/mushroom_stew.json
+++ b/src/main/resources/data/minecraft/recipes/mushroom_stew.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "bonappetit:salt"
+      "tag": "c:salt"
     },
     {
       "tag": "minecraft:mushrooms"

--- a/src/main/resources/data/minecraft/recipes/rabbit_stew.json
+++ b/src/main/resources/data/minecraft/recipes/rabbit_stew.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "bonappetit:salt"
+      "tag": "c:salt"
     },
     {
       "item": "minecraft:cooked_rabbit"

--- a/src/main/resources/data/minecraft/tags/items/vegetables.json
+++ b/src/main/resources/data/minecraft/tags/items/vegetables.json
@@ -4,7 +4,7 @@
     "minecraft:potato",
     "minecraft:carrot",
     "minecraft:beetroot",
-    "bonappetit:tomato",
-    "bonappetit:onion"
+    "c:tomato",
+    "c:onion"
   ]
 }


### PR DESCRIPTION
This pull request adds Bon Appetit's salt, tomato and onion items to the *c* tags for these items, so that other mods with their own salt, tomatoes or onions that use the tags can use Bon Appetit's in their recipes. This pull request also makes all of Bon Appetit's recipes involving these three items use the tags instead, so that other mods' salt, tomatoes and onions can be used in its recipes.
I didn't make the salt block recipe use #c:salt, as the salt block is more specific to this mod's salt in particular.

This is a good thing to have for compatibility with other mods that use these tags, such as Sandwichable or Croptopia.